### PR TITLE
Remove softdelete functionality for feeds.Item

### DIFF
--- a/internal/feeds/feeds.go
+++ b/internal/feeds/feeds.go
@@ -52,7 +52,9 @@ type Feed struct {
 
 // The Item struct stores an item from an RSS feed.
 type Item struct {
-	gorm.Model
+	ID                 uint `gorm:"primaryKey"`
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
 	Title              string
 	FeedAbbr           string
 	Link               string


### PR DESCRIPTION
- Previous version uses gorm.Model for declaring `feeds.Item` -- this includes a `deleted_at` field, which turns on a 'soft delete' functionality
- Although gorm creates an index on `deleted_at`, in practice the queries were dramatically slower (650x slower in my testing!) than a query that didn't filter for `deleted_at` being `NULL`
- Since we don't need the soft delete functionality, we're now declaring the gorm fields ID, CreatedAt and UpdatedAt directly in the `feeds.Item` struct
- Queries now execute as expected